### PR TITLE
Add New Tex Command for "oiint" and "oiiint"

### DIFF
--- a/source/main.ptx
+++ b/source/main.ptx
@@ -26,9 +26,11 @@
       \newcommand{\vol}{\,\text{vol}}
       \newcommand{\orient}{\,\text{or}}
       \newcommand{\pball}[2]{\text{B}^*_{#1} ( #2 )}
+      \newcommand{\oiint}{{\subset\!\supset} \llap{\iint}}
+      \newcommand{\oiiint}{{\large{\subset\!\supset}} \llap{\iiint}}
     </macros>
     <latex-image-preamble>
-      \usepackage{tikz, tikz-cd, amscd, esint}
+      \usepackage{tikz, tikz-cd, amscd}
       \usetikzlibrary{arrows}
     </latex-image-preamble>
   </docinfo>


### PR DESCRIPTION
According to section 4.9.16 of [the pretext book](https://pretextbook.org/doc/guide/html/topic-mathematics.html), for a list of supported extensions see MathJax’s [TeX/LaTeX Extension List](https://docs.mathjax.org/en/latest/input/tex/extensions/index.html). Because it's not included, I removed "esint" from the "latex-image-preamble". Based on [this math meta stack exchange post](https://math.meta.stackexchange.com/a/34771), I added definitions for double and triple contour integrals. Although it's a hack, it seems to be the best we can do, and it doesn't look too bad.
![oiint](https://github.com/user-attachments/assets/6a68772e-15fe-43ae-b308-98327988c382)
