### PR TITLE
Fixed Expressions in Examples 5.1.2 and 5.1.4

### DIFF
--- a/source/derivatives.xml
+++ b/source/derivatives.xml
@@ -35,7 +35,7 @@
             <statement>
                 <p>For a differentiable function <m>f</m> on an open set <m>U</m>, which is a <m>0</m>-form by definition, of <m>\mathbb{R}^n</m>, we recall 
                 <me>
-                    \tder{}{f} = \frac{\partial f}{\partial x_1} \tder{}{x_1} + \cdots + \frac{\partial f{\partial x_n} \tder{}{x_n} .
+                    \tder{}{f} = \frac{\partial f}{\partial x_1} \tder{}{x_1} + \cdots + \frac{\partial f}{\partial x_n} \tder{}{x_n} .
                 </me>
                 So, for example if <m>f(x,y) = x \cos (xy)</m> then 
                 <me>
@@ -67,7 +67,7 @@
             <statement>
                 <p>For the <m>2</m>-form 
                     <me>
-                        \xi \amp = xz \, \tder{}{x} \wedge \tder{}{y} - xy \, \tder{}{y} \wedge \tder{}{z}
+                        \xi = xz \, \tder{}{x} \wedge \tder{}{y} - xy \, \tder{}{y} \wedge \tder{}{z}
                     </me> 
                     one calculates
                     <md>


### PR DESCRIPTION
To Example 5.1.2 I added a missing curly brace in a \frac. To Example 5.1.4 I removed a \amp that was not inside a <mrow></mrow>. I just removed it instead of putting it inside an mrow because it was just a single line and so aligning it did nothing